### PR TITLE
Add return to all videos icon link

### DIFF
--- a/BasicContent/_VideoDetail.cshtml
+++ b/BasicContent/_VideoDetail.cshtml
@@ -29,6 +29,14 @@
     <div class="container position-relative">
         <div class="row">
             <div class="col-md-2 col-sm-1"></div>
+            <div class="col-12 col-md-9 align-items-center mt-1">
+                <a class="text-main-shade" href="https://dnndave.com"><i class="fas fa-reply-all fa-1x mr-1"></i></a>
+                <a class="text-white" href="https://dnndave.com"><span class="font-weight-bold">RETURN</span></a>
+            </div>
+            <div class="col-md-2 col-sm-1"></div>
+        </div>
+        <div class="row">
+            <div class="col-md-2 col-sm-1"></div>
             <div class="col-12 col-md-8 col-sm-10 py-1">
                 <div @Edit.TagToolbar(Content, actions: "edit", settings: new { hover = "left" })>
                     <picture>


### PR DESCRIPTION
This PR adds a return icon link to the top of the video detail template:

![image](https://user-images.githubusercontent.com/4568451/221374284-2776a40b-c335-49bf-aad1-76124a4e7812.png)
