### PR TITLE
Resolve Twitter card meta tag issues

### DIFF
--- a/BasicContent/_VideoDetail.cshtml
+++ b/BasicContent/_VideoDetail.cshtml
@@ -18,11 +18,11 @@
     page.AddOpenGraph("url", @CmsContext.Site.Url + "/Videos/Video/Episode/" + video.Slug);
 
     page.AddMeta("twitter:card", "summary_large_image");
-    page.AddMeta("twitter:domain", @CmsContext.Site.UrlRoot);
-    page.AddMeta("twitter:url", @CmsContext.Site.Url + "/Videos/Video/Episode/" + video.Slug);
+    page.AddMeta("twitter:site", "@davidpoindexter");
     page.AddMeta("twitter:title", video.Title);
     page.AddMeta("twitter:description", video.Summary);
     page.AddMeta("twitter:image", @CmsContext.Site.Url + video.Image);
+    page.AddMeta("twitter:image:alt", "Graphic for the '" + video.Title + "' video");
 }
 
 <div id="episode-@(Content.EntityId)" class="d-flex align-items-center episode-550 button-wrapper-fix">


### PR DESCRIPTION
This PR resolves the Twitter card meta tags issue.  Now all information shows up properly when sharing a video detail page link on Twitter.

![image](https://user-images.githubusercontent.com/4568451/221374997-4c5db698-685b-4905-920b-04be933e581f.png)
